### PR TITLE
Update ScreenBrightnessModule.java

### DIFF
--- a/android/src/main/java/com/robinpowered/react/ScreenBrightness/ScreenBrightnessModule.java
+++ b/android/src/main/java/com/robinpowered/react/ScreenBrightness/ScreenBrightnessModule.java
@@ -255,7 +255,7 @@ public class ScreenBrightnessModule extends ReactContextBaseJavaModule
      */
     @ReactMethod
     public void getBrightness(final Promise promise) {
-        getSystemBrightness(promise);
+        getAppBrightness(promise);
     }
 
     /**
@@ -268,6 +268,6 @@ public class ScreenBrightnessModule extends ReactContextBaseJavaModule
      */
     @ReactMethod
     public void setBrightness(float brightness, final Promise promise) {
-        setSystemBrightness(brightness, promise);
+        setAppBrightness(brightness, promise);
     }
 }


### PR DESCRIPTION
changed to use app brightness on android instead of system brightness
system brightness does not work on my lg x230 with android 6